### PR TITLE
move shadow build config to netty subproject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,4 +83,3 @@ subprojects {
 }
 
 apply from: file('gradle/check.gradle')
-apply from: file('gradle/shadow.gradle')

--- a/mantis-publish-netty/build.gradle
+++ b/mantis-publish-netty/build.gradle
@@ -22,3 +22,5 @@ dependencies {
     implementation project(':mantis-publish-core')
     implementation "io.netty:netty-all:$nettyVersion"
 }
+
+apply from: file('../gradle/shadow.gradle')


### PR DESCRIPTION
### Context

Don't build shadow jar for core sub-project

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
