### PR TITLE
cleanup builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ ext {
     junitVersion = '5.3.+'
     mockitoVersion = '2.18.+'
     slf4jVersion = '1.7.+'
+    jacksonVersion = 'latest.release'
+    mantisDiscoveryVersion = '1.2.+'
+    spectatorVersion = 'latest.release'
+    archaiusVersion = 'latest.release'
 }
 
 allprojects {

--- a/gradle/shadow.gradle
+++ b/gradle/shadow.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-subprojects {
+project(":mantis-publish-netty") {
     shadowJar {
         classifier = null
         relocate('com.fasterxml', 'io.mantisrx.shaded.com.fasterxml')

--- a/mantis-publish-core/build.gradle
+++ b/mantis-publish-core/build.gradle
@@ -15,21 +15,21 @@
  */
 
 ext {
-    archaiusVersion = '2.3.+'
-    jacksonVersion = '2.8.+'
-    mqlVersion = '3.+'
-    spectatorVersion = '0.82.+'
-    mantisDiscoveryVersion = '1.+'
+    archaiusVersion = 'latest.release'
+    jacksonVersion = 'latest.release'
+    mqlVersion = 'latest.release'
+    spectatorVersion = 'latest.release'
+    mantisDiscoveryVersion = '1.2.+'
 }
 
 dependencies {
     api "io.mantisrx:mql-jvm:$mqlVersion"
     api "io.mantisrx:mantis-discovery-proto:$mantisDiscoveryVersion"
 
-    api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
     api "com.netflix.spectator:spectator-api:$spectatorVersion"
-    api "com.netflix.spectator:spectator-ext-ipc:$spectatorVersion"
+    implementation "com.netflix.spectator:spectator-ext-ipc:$spectatorVersion"
     api "com.netflix.archaius:archaius2-api:$archaiusVersion"
     api "com.netflix.archaius:archaius2-core:$archaiusVersion"
 

--- a/mantis-publish-core/build.gradle
+++ b/mantis-publish-core/build.gradle
@@ -15,23 +15,21 @@
  */
 
 ext {
-    archaiusVersion = 'latest.release'
-    jacksonVersion = 'latest.release'
     mqlVersion = 'latest.release'
-    spectatorVersion = 'latest.release'
-    mantisDiscoveryVersion = '1.2.+'
 }
 
 dependencies {
-    api "io.mantisrx:mql-jvm:$mqlVersion"
-    api "io.mantisrx:mantis-discovery-proto:$mantisDiscoveryVersion"
+    implementation "io.mantisrx:mql-jvm:$mqlVersion"
+    implementation "io.mantisrx:mantis-discovery-proto:$mantisDiscoveryVersion"
 
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
+
     api "com.netflix.spectator:spectator-api:$spectatorVersion"
     implementation "com.netflix.spectator:spectator-ext-ipc:$spectatorVersion"
+
     api "com.netflix.archaius:archaius2-api:$archaiusVersion"
-    api "com.netflix.archaius:archaius2-core:$archaiusVersion"
+    implementation "com.netflix.archaius:archaius2-core:$archaiusVersion"
 
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.21.0"
     testCompileOnly "com.netflix.archaius:archaius2-core:$archaiusVersion"

--- a/mantis-publish-netty/build.gradle
+++ b/mantis-publish-netty/build.gradle
@@ -20,7 +20,14 @@ ext {
 
 dependencies {
     implementation project(':mantis-publish-core')
+    implementation "io.mantisrx:mantis-discovery-proto:$mantisDiscoveryVersion"
     implementation "io.netty:netty-all:$nettyVersion"
+
+    implementation "com.netflix.spectator:spectator-ext-ipc:$spectatorVersion"
+    implementation "com.netflix.archaius:archaius2-core:$archaiusVersion"
+
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
 }
 
 apply from: file('../gradle/shadow.gradle')


### PR DESCRIPTION
### Context

- Use implementation instead of api for transitive dependencies that should not be visible to app consuming the library
- fix shadow config to only apply to netty subproject
- use latest.release for netflix dependencies to allow resolution rules to resolve to right version when running inside Netflix

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
