### PR TITLE
return status from the event publish API

### DIFF
--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/MantisEventPublisher.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/MantisEventPublisher.java
@@ -18,6 +18,9 @@ package io.mantisrx.publish;
 
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import io.mantisrx.publish.api.Event;
 import io.mantisrx.publish.api.EventPublisher;
 import io.mantisrx.publish.api.PublishStatus;
@@ -44,15 +47,19 @@ public class MantisEventPublisher implements EventPublisher {
     }
 
     @Override
-    public PublishStatus publish(final Event event) {
+    public CompletionStage<PublishStatus> publish(final Event event) {
         return publish(StreamType.DEFAULT_EVENT_STREAM, event);
     }
 
     @Override
-    public PublishStatus publish(final String streamName, final Event event) {
+    public CompletionStage<PublishStatus> publish(final String streamName, final Event event) {
 
         if (!isEnabled()) {
-            return PublishStatus.SKIPPED_CLIENT_NOT_ENABLED;
+            return CompletableFuture.completedFuture(PublishStatus.SKIPPED_CLIENT_NOT_ENABLED);
+        }
+
+        if (event == null || event.isEmpty()) {
+            return CompletableFuture.completedFuture(PublishStatus.SKIPPED_INVALID_EVENT);
         }
 
         final Optional<BlockingQueue<Event>> streamQ = streamManager.registerStream(streamName);
@@ -63,10 +70,11 @@ public class MantisEventPublisher implements EventPublisher {
                 boolean success = streamQ.get().offer(event);
                 if (!success) {
                     streamMetricsO.ifPresent(m -> m.getMantisEventsDroppedCounter().increment());
-                    return PublishStatus.FAILED_QUEUE_FULL;
+                    return CompletableFuture.completedFuture(PublishStatus.FAILED_QUEUE_FULL);
                 } else {
                     streamMetricsO.ifPresent(m -> m.getMantisEventsProcessedCounter().increment());
-                    return PublishStatus.ENQUEUED;
+                    // TODO - propagate a Promise of PublishStatus with the Event and update status async after network send to Mantis
+                    return CompletableFuture.completedFuture(PublishStatus.ENQUEUED);
                 }
             } else {
                 // Don't enqueue the event if there are no active subscriptions for this stream.
@@ -74,11 +82,11 @@ public class MantisEventPublisher implements EventPublisher {
                     m.getMantisActiveQueryCountGauge().set(0.0);
                     m.getMantisEventsSkippedCounter().increment();
                 });
-                return PublishStatus.SKIPPED_NO_SUBSCRIPTIONS;
+                return CompletableFuture.completedFuture(PublishStatus.SKIPPED_NO_SUBSCRIPTIONS);
             }
         } else {
             // failed to register stream, this could happen if max stream limit is exceeded
-            return PublishStatus.FAILED_STREAM_NOT_REGISTERED;
+            return CompletableFuture.completedFuture(PublishStatus.FAILED_STREAM_NOT_REGISTERED);
         }
     }
 

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/api/EventPublisher.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/api/EventPublisher.java
@@ -16,25 +16,51 @@
 
 package io.mantisrx.publish.api;
 
+import java.util.concurrent.CompletionStage;
+
 import io.mantisrx.publish.core.Subscription;
 
 
 public interface EventPublisher {
 
     /**
-     * Publishes an event on the {@value StreamType#DEFAULT_EVENT_STREAM} stream.
-     *
-     * @param event event data to publish to Mantis
-     */
-    PublishStatus publish(Event event);
-
-    /**
      * Publishes an event on the given stream.
      *
      * @param streamName name of the stream to publish the event to
      * @param event      event data to publish to Mantis
+     * @return {@link CompletionStage<PublishStatus>} status of publishing the message
      */
-    PublishStatus publish(String streamName, Event event);
+    CompletionStage<PublishStatus> publish(String streamName, Event event);
+
+    /**
+     * Publishes an event on the {@value StreamType#DEFAULT_EVENT_STREAM} stream.
+     * <p>To publish an Event, use the following code:
+     * <pre>   {@code
+     *   eventPublisher.publish(new Event(attr))
+     *      .whenComplete((s, t) -> {
+     *     if (t != null) {
+     *         LOG.error("caught exception processing event", t);
+     *     } else {
+     *         switch (s.getStatus()) {
+     *             case SENDING:
+     *             case SENT:
+     *                 // success
+     *                 break;
+     *             case PRECONDITION_FAILED:
+     *                 // message was skipped due to client being disabled, no active MQL subs etc,increment a counter for visibility
+     *                 break;
+     *             case FAILED:
+     *                 // error sending message, increment a counter and raise an alarm if too many failures
+     *                 LOG.error("failed to send event", s);
+     *                 break;
+     *             default:
+     *         }
+     *     }
+     * });</pre>
+     * @param event event data to publish to Mantis
+     * @return {@link CompletionStage<PublishStatus>} status of publishing the message
+     */
+    CompletionStage<PublishStatus> publish(Event event);
 
     /**
      * Returns whether or not this event publisher has active {@link Subscription}s.

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/api/EventPublisher.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/api/EventPublisher.java
@@ -16,7 +16,6 @@
 
 package io.mantisrx.publish.api;
 
-
 import io.mantisrx.publish.core.Subscription;
 
 
@@ -27,7 +26,7 @@ public interface EventPublisher {
      *
      * @param event event data to publish to Mantis
      */
-    void publish(Event event);
+    PublishStatus publish(Event event);
 
     /**
      * Publishes an event on the given stream.
@@ -35,7 +34,7 @@ public interface EventPublisher {
      * @param streamName name of the stream to publish the event to
      * @param event      event data to publish to Mantis
      */
-    void publish(String streamName, Event event);
+    PublishStatus publish(String streamName, Event event);
 
     /**
      * Returns whether or not this event publisher has active {@link Subscription}s.

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/api/PublishStatus.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/api/PublishStatus.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.publish.api;
+
+public enum PublishStatus {
+    /**
+     * Successfully enqueued the message for further MQL processing.
+     * This only indicates enqueue success and does not indicate the message was successfully MQL processed and sent to Mantis
+     */
+    ENQUEUED,
+
+    // Skipped messages due to no active subscriptions or publishing being disabled from config
+    /**
+     * Message was not enqueued since there are no active MQL subscriptions for the streamName
+     */
+    SKIPPED_NO_SUBSCRIPTIONS,
+    /**
+     * Message was not enqueued since the Mantis Publish client is not enabled in configuration
+     */
+    SKIPPED_CLIENT_NOT_ENABLED,
+
+    // Messages dropped due to failures like burst in incoming traffic, too many stream queues created, transport issues
+    /**
+     * Message enqueue failed due to stream queue being full
+     */
+    FAILED_QUEUE_FULL,
+    /**
+     * Message enqueue failed as the stream could not be registered, this could happen if max number of streams allowed is exceeded
+     */
+    FAILED_STREAM_NOT_REGISTERED
+}

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/api/PublishStatus.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/api/PublishStatus.java
@@ -16,30 +16,81 @@
 
 package io.mantisrx.publish.api;
 
+/**
+ * Indicates the result of publishing an Event to Mantis.
+ */
 public enum PublishStatus {
     /**
      * Successfully enqueued the message for further MQL processing.
      * This only indicates enqueue success and does not indicate the message was successfully MQL processed and sent to Mantis
      */
-    ENQUEUED,
+    ENQUEUED(Status.SENDING),
 
-    // Skipped messages due to no active subscriptions or publishing being disabled from config
+    // Skipped events due to precondition failures like no active subscriptions, publishing not enabled in configuration
     /**
-     * Message was not enqueued since there are no active MQL subscriptions for the streamName
+     * Event was not enqueued since there are no active MQL subscriptions for the streamName
      */
-    SKIPPED_NO_SUBSCRIPTIONS,
+    SKIPPED_NO_SUBSCRIPTIONS(Status.PRECONDITION_FAILED),
     /**
-     * Message was not enqueued since the Mantis Publish client is not enabled in configuration
+     * Event was not enqueued since the Mantis Publish client is not enabled in configuration
      */
-    SKIPPED_CLIENT_NOT_ENABLED,
+    SKIPPED_CLIENT_NOT_ENABLED(Status.PRECONDITION_FAILED),
 
-    // Messages dropped due to failures like burst in incoming traffic, too many stream queues created, transport issues
     /**
-     * Message enqueue failed due to stream queue being full
+     * Event was not enqueued since the event was invalid (either null or empty)
      */
-    FAILED_QUEUE_FULL,
+    SKIPPED_INVALID_EVENT(Status.PRECONDITION_FAILED),
+
+    // Events dropped due to failures like burst in incoming traffic, too many stream queues created, transport issues
     /**
-     * Message enqueue failed as the stream could not be registered, this could happen if max number of streams allowed is exceeded
+     * Event enqueue failed due to stream queue being full
      */
-    FAILED_STREAM_NOT_REGISTERED
+    FAILED_QUEUE_FULL(Status.FAILED),
+    /**
+     * Event enqueue failed as the stream could not be registered, this could happen if max number of streams allowed per config is exceeded
+     */
+    FAILED_STREAM_NOT_REGISTERED(Status.FAILED),
+    /**
+     * Event could not be sent as the Mantis Worker Info is unavailable for configured Mantis Job Cluster
+     */
+    FAILED_WORKER_INFO_UNAVAILABLE(Status.FAILED),
+    /**
+     * Event processing failed to project superset
+     */
+    FAILED_SUPERSET_PROJECTION(Status.FAILED);
+
+    public enum Status {
+        /**
+         * Indicates the event was skipped as expected due to a precondition failure
+         */
+        PRECONDITION_FAILED,
+        /**
+         * Indicates the event is being sent (considered a successful send until {@link Status#SENT} is implemented).
+         * Clients should consider either a {@link Status#SENDING} or {@link Status#SENT} status as a Success to stay forward compatible.
+         */
+        SENDING,
+        /**
+         * Not currently implemented but in future would indicate an event was successfully sent over the network to Mantis for further propagation
+         */
+        SENT,
+        /**
+         * Failed to send the event
+         */
+        FAILED
+    }
+
+    private final Status status;
+
+    PublishStatus(Status status) {
+        this.status = status;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + "(" + status + ')';
+    }
 }

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/proto/InstanceInfo.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/proto/InstanceInfo.java
@@ -68,9 +68,9 @@ public class InstanceInfo {
         if (o == null || getClass() != o.getClass()) return false;
         InstanceInfo that = (InstanceInfo) o;
         return Objects.equals(getApplicationName(), that.getApplicationName()) &&
-                Objects.equals(getZone(), that.getZone()) &&
-                Objects.equals(getClusterName(), that.getClusterName()) &&
-                Objects.equals(getAutoScalingGroupName(), that.getAutoScalingGroupName());
+            Objects.equals(getZone(), that.getZone()) &&
+            Objects.equals(getClusterName(), that.getClusterName()) &&
+            Objects.equals(getAutoScalingGroupName(), that.getAutoScalingGroupName());
     }
 
     @Override
@@ -81,12 +81,12 @@ public class InstanceInfo {
     @Override
     public String toString() {
         return "InstanceInfo{" +
-                "applicationName='" + applicationName + '\'' +
-                ", zone='" + zone + '\'' +
-                ", clusterName='" + clusterName + '\'' +
-                ", autoScalingGroupName='" + autoScalingGroupName + '\'' +
-                ", instanceStatus=" + instanceStatus +
-                '}';
+            "applicationName='" + applicationName + '\'' +
+            ", zone='" + zone + '\'' +
+            ", clusterName='" + clusterName + '\'' +
+            ", autoScalingGroupName='" + autoScalingGroupName + '\'' +
+            ", instanceStatus=" + instanceStatus +
+            '}';
     }
 
     public enum InstanceStatus {

--- a/mantis-publish-core/src/test/java/io/mantisrx/publish/MantisEventPublisherTest.java
+++ b/mantis-publish-core/src/test/java/io/mantisrx/publish/MantisEventPublisherTest.java
@@ -17,12 +17,20 @@
 package io.mantisrx.publish;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import com.netflix.archaius.DefaultPropertyFactory;
 import com.netflix.archaius.api.PropertyRepository;
@@ -52,55 +60,88 @@ public class MantisEventPublisherTest {
         streamManager = mock(StreamManager.class);
     }
 
+    private void assertStatusAsync(PublishStatus expected, CompletionStage<PublishStatus> actualF) {
+        final CountDownLatch latch = new CountDownLatch(1);
+        actualF.whenComplete((s, t) -> {
+            try {
+                assertEquals(expected, s);
+                latch.countDown();
+            } catch (Exception e) {
+                e.printStackTrace();
+                fail(e.getMessage());
+            }
+        });
+        try {
+            assertTrue("timed out waiting for status callback", latch.await(1, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+    }
+
+    private Event testEvent() {
+        return new Event(new HashMap<>(Collections.singletonMap("k", "v")));
+    }
+
     @Test
-    public void testPublisherEnqueue() {
+    public void testPublishStatusEnqueued() {
         when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.of(new LinkedBlockingDeque<>()));
         when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(true);
         boolean publishEnabled = true;
         MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
-        PublishStatus status = eventPublisher.publish(new Event());
-        assertEquals(PublishStatus.ENQUEUED, status);
+        CompletionStage<PublishStatus> statusF = eventPublisher.publish(new Event(new HashMap<>(Collections.singletonMap("k", "v"))));
+        assertStatusAsync(PublishStatus.ENQUEUED, statusF);
     }
 
     @Test
-    public void testPublishMessageSkipStatusWhenDisabled() {
+    public void testPublishStatusSkipOnDisabled() {
         when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.of(new LinkedBlockingDeque<>()));
         when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(true);
         boolean publishEnabled = false;
         MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
-        PublishStatus status = eventPublisher.publish(new Event());
-        assertEquals(PublishStatus.SKIPPED_CLIENT_NOT_ENABLED, status);
+        CompletionStage<PublishStatus> statusF = eventPublisher.publish(testEvent());
+        assertStatusAsync(PublishStatus.SKIPPED_CLIENT_NOT_ENABLED, statusF);
     }
 
     @Test
-    public void testPublishMessageSkipStatusWhenNoSubscriptions() {
+    public void testPublishStatusSkipOnInvalidEvent() {
+        when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.of(new LinkedBlockingDeque<>()));
+        when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(true);
+        boolean publishEnabled = true;
+        MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
+        CompletionStage<PublishStatus> statusF = eventPublisher.publish(new Event());
+        assertStatusAsync(PublishStatus.SKIPPED_INVALID_EVENT, statusF);
+    }
+
+    @Test
+    public void testPublishStatusSkipOnNoSubscriptions() {
         when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.of(new LinkedBlockingDeque<>()));
         when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(false);
         boolean publishEnabled = true;
         MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
-        PublishStatus status = eventPublisher.publish(new Event());
-        assertEquals(PublishStatus.SKIPPED_NO_SUBSCRIPTIONS, status);
+        CompletionStage<PublishStatus> statusF = eventPublisher.publish(testEvent());
+        assertStatusAsync(PublishStatus.SKIPPED_NO_SUBSCRIPTIONS, statusF);
     }
 
     @Test
-    public void testPublishMessageFailStatusWhenStreamNotRegistered() {
+    public void testPublishStatusFailOnStreamNotRegistered() {
         when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.empty());
         when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(true);
         boolean publishEnabled = true;
         MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
-        PublishStatus status = eventPublisher.publish(new Event());
-        assertEquals(PublishStatus.FAILED_STREAM_NOT_REGISTERED, status);
+        CompletionStage<PublishStatus> statusF = eventPublisher.publish(testEvent());
+        assertStatusAsync(PublishStatus.FAILED_STREAM_NOT_REGISTERED, statusF);
     }
 
     @Test
-    public void testPublishMessageFailStatusWhenQueueFull() {
+    public void testPublishStatusFailOnQueueFull() {
         when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.ofNullable(new LinkedBlockingQueue<>(1)));
         when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(true);
         boolean publishEnabled = true;
         MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
-        PublishStatus status = eventPublisher.publish(new Event());
-        assertEquals(PublishStatus.ENQUEUED, status);
-        PublishStatus status2 = eventPublisher.publish(new Event());
-        assertEquals(PublishStatus.FAILED_QUEUE_FULL, status2);
+        CompletionStage<PublishStatus> statusF = eventPublisher.publish(testEvent());
+        statusF.whenComplete((s, t) -> assertEquals(PublishStatus.ENQUEUED, s));
+        CompletionStage<PublishStatus> statusF2 = eventPublisher.publish(testEvent());
+        statusF2.whenComplete((s, t) -> assertEquals(PublishStatus.FAILED_QUEUE_FULL, s));
     }
 }

--- a/mantis-publish-core/src/test/java/io/mantisrx/publish/MantisEventPublisherTest.java
+++ b/mantis-publish-core/src/test/java/io/mantisrx/publish/MantisEventPublisherTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.publish;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.netflix.archaius.DefaultPropertyFactory;
+import com.netflix.archaius.api.PropertyRepository;
+import com.netflix.archaius.config.DefaultSettableConfig;
+import io.mantisrx.publish.api.Event;
+import io.mantisrx.publish.api.PublishStatus;
+import io.mantisrx.publish.api.StreamType;
+import io.mantisrx.publish.config.MrePublishConfiguration;
+import io.mantisrx.publish.config.SampleArchaiusMrePublishConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class MantisEventPublisherTest {
+
+    private MrePublishConfiguration testConfig(boolean mantisPublishClientEnabled) {
+        DefaultSettableConfig settableConfig = new DefaultSettableConfig();
+        settableConfig.setProperty(SampleArchaiusMrePublishConfiguration.MRE_CLIENT_ENABLED_PROP, mantisPublishClientEnabled);
+        PropertyRepository propertyRepository = DefaultPropertyFactory.from(settableConfig);
+        return new SampleArchaiusMrePublishConfiguration(propertyRepository);
+    }
+
+    private StreamManager streamManager;
+
+    @Before
+    public void setup() {
+        streamManager = mock(StreamManager.class);
+    }
+
+    @Test
+    public void testPublisherEnqueue() {
+        when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.of(new LinkedBlockingDeque<>()));
+        when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(true);
+        boolean publishEnabled = true;
+        MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
+        PublishStatus status = eventPublisher.publish(new Event());
+        assertEquals(PublishStatus.ENQUEUED, status);
+    }
+
+    @Test
+    public void testPublishMessageSkipStatusWhenDisabled() {
+        when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.of(new LinkedBlockingDeque<>()));
+        when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(true);
+        boolean publishEnabled = false;
+        MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
+        PublishStatus status = eventPublisher.publish(new Event());
+        assertEquals(PublishStatus.SKIPPED_CLIENT_NOT_ENABLED, status);
+    }
+
+    @Test
+    public void testPublishMessageSkipStatusWhenNoSubscriptions() {
+        when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.of(new LinkedBlockingDeque<>()));
+        when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(false);
+        boolean publishEnabled = true;
+        MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
+        PublishStatus status = eventPublisher.publish(new Event());
+        assertEquals(PublishStatus.SKIPPED_NO_SUBSCRIPTIONS, status);
+    }
+
+    @Test
+    public void testPublishMessageFailStatusWhenStreamNotRegistered() {
+        when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.empty());
+        when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(true);
+        boolean publishEnabled = true;
+        MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
+        PublishStatus status = eventPublisher.publish(new Event());
+        assertEquals(PublishStatus.FAILED_STREAM_NOT_REGISTERED, status);
+    }
+
+    @Test
+    public void testPublishMessageFailStatusWhenQueueFull() {
+        when(streamManager.registerStream(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(Optional.ofNullable(new LinkedBlockingQueue<>(1)));
+        when(streamManager.hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM)).thenReturn(true);
+        boolean publishEnabled = true;
+        MantisEventPublisher eventPublisher = new MantisEventPublisher(testConfig(publishEnabled), streamManager);
+        PublishStatus status = eventPublisher.publish(new Event());
+        assertEquals(PublishStatus.ENQUEUED, status);
+        PublishStatus status2 = eventPublisher.publish(new Event());
+        assertEquals(PublishStatus.FAILED_QUEUE_FULL, status2);
+    }
+}


### PR DESCRIPTION
### Context

Return PublishStatus from the event publish API to indicate status to caller

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
