### PR TITLE
refresh control plane lazily after EventPublisher API invoked

### DIFF
--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/AbstractSubscriptionTracker.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/AbstractSubscriptionTracker.java
@@ -111,7 +111,8 @@ public abstract class AbstractSubscriptionTracker implements SubscriptionTracker
 
     @Override
     public void refreshSubscriptions() {
-        if (mrePublishConfiguration.isMREClientEnabled()) {
+        // refresh subscriptions only if the Publish client is enabled and has streams registered by MantisEventPublisher
+        if (mrePublishConfiguration.isMREClientEnabled() && !streamManager.getRegisteredStreams().isEmpty()) {
             for (Map.Entry<String, String> e : mrePublishConfiguration.streamNameToJobClusterMapping().entrySet()) {
                 String streamName = e.getKey();
                 if (streamManager.getRegisteredStreams().contains(streamName) || StreamJobClusterMap.DEFAULT_STREAM_KEY.equals(streamName)) {


### PR DESCRIPTION
### Context
make control plane refreshes lazy, refresh subscriptions only if EventPublisher API was invoked to publish events or check for subscriptions

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
