### PR TITLE
add subscription refresh invoked counter

### DIFF
--- a/mantis-publish-core/build.gradle
+++ b/mantis-publish-core/build.gradle
@@ -15,7 +15,7 @@
  */
 
 ext {
-    mqlVersion = 'latest.release'
+    mqlVersion = '3.1.5'
     mantisDiscoveryVersion = '1.2.+'
 }
 


### PR DESCRIPTION
### Context
add subscription refresh invoked counter for operational visibility

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
