### PR TITLE
Add default constructor to MantisEnvelope

### DIFF
--- a/mantis-publish-netty/src/main/java/io/mantisrx/publish/netty/proto/MantisEvent.java
+++ b/mantis-publish-netty/src/main/java/io/mantisrx/publish/netty/proto/MantisEvent.java
@@ -63,4 +63,12 @@ public class MantisEvent {
     public int hashCode() {
         return Objects.hash(getId(), getData());
     }
+
+    @Override
+    public String toString() {
+        return "MantisEvent{" +
+                "id=" + id +
+                ", data='" + data + '\'' +
+                '}';
+    }
 }

--- a/mantis-publish-netty/src/main/java/io/mantisrx/publish/netty/proto/MantisEventEnvelope.java
+++ b/mantis-publish-netty/src/main/java/io/mantisrx/publish/netty/proto/MantisEventEnvelope.java
@@ -24,10 +24,16 @@ import java.util.List;
 
 public class MantisEventEnvelope {
 
-    private final String originServer;
-    private final List<MantisEvent> eventList;
+    private String originServer;
+    private List<MantisEvent> eventList;
     private long ts;
 
+    /**
+     * For JSON serde
+     */
+    public MantisEventEnvelope() {
+
+    }
     @JsonCreator
     public MantisEventEnvelope(@JsonProperty("ts") long ts, @JsonProperty("originServer") String originServer,
                                @JsonProperty("events") List<MantisEvent> eventList) {
@@ -54,5 +60,14 @@ public class MantisEventEnvelope {
 
     public void addEvent(MantisEvent event) {
         eventList.add(event);
+    }
+
+    @Override
+    public String toString() {
+        return "MantisEventEnvelope{" +
+                "originServer='" + originServer + '\'' +
+                ", eventList=" + eventList +
+                ", ts=" + ts +
+                '}';
     }
 }

--- a/mantis-publish-netty/src/test/java/io/mantisrx/publish/netty/proto/MantisEnvelopeTest.java
+++ b/mantis-publish-netty/src/test/java/io/mantisrx/publish/netty/proto/MantisEnvelopeTest.java
@@ -1,0 +1,28 @@
+package io.mantisrx.publish.netty.proto;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.junit.jupiter.api.Test;
+
+
+public class MantisEnvelopeTest {
+
+    @Test
+    public void deserTest() {
+        String data = "{\"ts\":1571174446676,\"originServer\":\"origin\",\"eventList\":[{\"id\":1,\"data\":\"{\\\"mantisStream\\\":\\\"defaultStream\\\",\\\"matched-clients\\\":[\\\"MantisPushRequestEvents_PushRequestEventSourceJobLocal-1_nj3\\\"],\\\"id\\\":44,\\\"type\\\":\\\"EVENT\\\"}\"}]}";
+        final ObjectMapper mapper = new ObjectMapper();
+        ObjectReader mantisEventEnvelopeReader = mapper.readerFor(MantisEventEnvelope.class);
+        try {
+            MantisEventEnvelope envelope = mantisEventEnvelopeReader.readValue(data);
+            System.out.println("Envelope=>" + envelope);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            fail();
+        }
+
+
+    }
+}


### PR DESCRIPTION
### Context

To avoid Jackson deserialization errors add a default constructor for MantisEnvelope.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
