### PR TITLE
Add a test implementation of MantisJobDiscovery for local testing.

### DIFF
--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/config/SampleArchaiusMrePublishConfiguration.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/config/SampleArchaiusMrePublishConfiguration.java
@@ -22,6 +22,9 @@ import java.util.Map;
 import com.netflix.archaius.api.Property;
 import com.netflix.archaius.api.PropertyRepository;
 import io.mantisrx.publish.api.StreamType;
+import io.mantisrx.publish.internal.discovery.MantisJobDiscovery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class SampleArchaiusMrePublishConfiguration implements MrePublishConfiguration {
@@ -104,8 +107,11 @@ public class SampleArchaiusMrePublishConfiguration implements MrePublishConfigur
     private final Property<Integer> workerPoolWorkerErrorQuota;
     private final Property<Integer> workerPoolWorkerErrorTimeoutSec;
 
+    private static final Logger LOG = LoggerFactory.getLogger(SampleArchaiusMrePublishConfiguration.class);
+
     public SampleArchaiusMrePublishConfiguration(final PropertyRepository propertyRepository) {
         this.propRepo = propertyRepository;
+
         this.mreClientEnabled =
                 propertyRepository.get(MRE_CLIENT_ENABLED_PROP, Boolean.class)
                         .orElse(true);
@@ -146,7 +152,7 @@ public class SampleArchaiusMrePublishConfiguration implements MrePublishConfigur
         this.jobClusterMappingRefreshIntervalSecProp = propRepo.get(JOB_CLUSTER_MAPPING_REFRESH_INTERVAL_SEC_PROP, Integer.class)
                 .orElse(60);
         this.subscriptionRefreshIntervalSecProp = propRepo.get(SUBS_REFRESH_INTERVAL_SEC_PROP, Integer.class)
-                .orElse(10);
+                .orElse(1);
         this.subscriptionExpiryIntervalSecProp = propRepo.get(SUBS_EXPIRY_INTERVAL_SEC_PROP, Integer.class)
                 .orElse(5 * 60);
         this.subsFetchQueryParamStr = propRepo.get(SUBS_FETCH_QUERY_PARAMS_STR_PROP, String.class)
@@ -261,10 +267,14 @@ public class SampleArchaiusMrePublishConfiguration implements MrePublishConfigur
 
     @Override
     public Map<String, String> streamNameToJobClusterMapping() {
+
         Map<String, String> mapping = new HashMap<>();
         // TBD: call discovery api to fetch mappings from stream to job cluster for current app
         mapping.put(StreamType.DEFAULT_EVENT_STREAM, mantisJobCluster(StreamType.DEFAULT_EVENT_STREAM));
         mapping.put(StreamType.LOG_EVENT_STREAM, mantisJobCluster(StreamType.LOG_EVENT_STREAM));
+        mapping.put(StreamType.REQUEST_EVENT_STREAM, mantisJobCluster(StreamType.DEFAULT_EVENT_STREAM));
+       // mapping.put(StreamJobClusterMap.DEFAULT_STREAM_KEY,mantisJobCluster(StreamType.DEFAULT_EVENT_STREAM));
+
         return mapping;
     }
 

--- a/mantis-publish-netty-guice/src/main/java/io/mantisrx/publish/netty/guice/MantisRealtimeEventsPublishModule.java
+++ b/mantis-publish-netty-guice/src/main/java/io/mantisrx/publish/netty/guice/MantisRealtimeEventsPublishModule.java
@@ -38,6 +38,7 @@ import io.mantisrx.publish.config.MrePublishConfiguration;
 import io.mantisrx.publish.config.SampleArchaiusMrePublishConfiguration;
 import io.mantisrx.publish.internal.discovery.MantisJobDiscovery;
 import io.mantisrx.publish.internal.discovery.MantisJobDiscoveryCachingImpl;
+import io.mantisrx.publish.internal.discovery.MantisJobDiscoveryStaticImpl;
 import io.mantisrx.publish.internal.discovery.mantisapi.DefaultMantisApiClient;
 import io.mantisrx.publish.netty.pipeline.HttpEventChannel;
 import io.mantisrx.publish.netty.pipeline.HttpEventChannelManager;
@@ -188,7 +189,7 @@ public class MantisRealtimeEventsPublishModule extends AbstractModule {
 
         @Inject
         private PropertyRepository propertyRepository;
-
+        
         @Override
         public MrePublishConfiguration get() {
             return new SampleArchaiusMrePublishConfiguration(propertyRepository);
@@ -207,6 +208,9 @@ public class MantisRealtimeEventsPublishModule extends AbstractModule {
         public MantisJobDiscovery get() {
             return new MantisJobDiscoveryCachingImpl(configuration, registry,
                     new DefaultMantisApiClient(configuration, HttpClient.create(registry)));
+            // for local testing swap in the static impl.
+            //return new MantisJobDiscoveryStaticImpl("127.0.0.1",9090);
+
         }
     }
 

--- a/mantis-publish-netty-guice/src/test/java/io/mantisrx/publish/netty/guice/LocalMantisPublishTester.java
+++ b/mantis-publish-netty-guice/src/test/java/io/mantisrx/publish/netty/guice/LocalMantisPublishTester.java
@@ -19,11 +19,17 @@ package io.mantisrx.publish.netty.guice;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.spectator.nflx.SpectatorModule;
+import io.mantisrx.publish.api.Event;
 import io.mantisrx.publish.api.EventPublisher;
+import io.mantisrx.publish.api.PublishStatus;
 import org.junit.jupiter.api.Test;
 
 
@@ -36,6 +42,18 @@ public class LocalMantisPublishTester {
                     new MantisRealtimeEventsPublishModule(), new SpectatorModule());
 
             EventPublisher publisher = injector.getInstance(EventPublisher.class);
+            /// FOR local testing uncomment
+//            for(int i=0; i<100; i++) {
+//                Map<String,Object> event = new HashMap<>();
+//                event.put("id",i);
+//                CompletionStage<PublishStatus> sendStatus = publisher.publish("requestEventStream", new Event(event));
+//                sendStatus.whenCompleteAsync((status, throwable) -> {
+//                    System.out.println("Send status => " + status);
+//                });
+//                Thread.sleep(1000);
+//            }
+
+
             assertNotNull(publisher);
         } catch(Exception e) {
             fail();


### PR DESCRIPTION

### Context

Add a test implementation of MantisJobDiscovery for local testing. Add requestEventStream mapping to default config


### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
