### PR TITLE
Add providers and refactor Configuration/JobDiscovery object.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @codyrioux @neerajrj @nickmahilani @jeffchao @piygoyal @skalidindi
+* @codyrioux @neerajrj @nickmahilani @jeffchao @piygoyal

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/DefaultSubscriptionTracker.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/DefaultSubscriptionTracker.java
@@ -49,13 +49,17 @@ public class DefaultSubscriptionTracker extends AbstractSubscriptionTracker {
     private final MantisJobDiscovery jobDiscovery;
     private final Random random = new Random();
 
-
-    public DefaultSubscriptionTracker(MrePublishConfiguration mrePublishConfiguration, Registry registry, StreamManager streamManager, HttpClient httpClient, MantisJobDiscovery jobDiscovery) {
-        super(mrePublishConfiguration, registry, streamManager);
+    public DefaultSubscriptionTracker(
+            MrePublishConfiguration mrePublishConfiguration,
+            Registry registry,
+            MantisJobDiscovery jobDiscovery,
+            StreamManager streamManager,
+            HttpClient httpClient) {
+        super(mrePublishConfiguration, registry, jobDiscovery, streamManager);
         this.mrePublishConfiguration = mrePublishConfiguration;
+        this.jobDiscovery = jobDiscovery;
         this.subscriptionsFetchQueryParamString = mrePublishConfiguration.subscriptionFetchQueryParams();
         this.httpClient = httpClient;
-        this.jobDiscovery = jobDiscovery;
 
         this.fetchSubscriptionsFailedCount = SpectatorUtils.buildAndRegisterCounter(registry, "fetchSubscriptionsFailedCount");
         this.fetchSubscriptionsNon200Count = SpectatorUtils.buildAndRegisterCounter(registry, "fetchSubscriptionsNon200Count");

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/EventDrainer.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/EventDrainer.java
@@ -25,11 +25,11 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
 import io.mantisrx.publish.api.Event;
 import io.mantisrx.publish.config.MrePublishConfiguration;
 import io.mantisrx.publish.internal.metrics.SpectatorUtils;
-import com.netflix.spectator.api.Registry;
-import com.netflix.spectator.api.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -102,7 +102,7 @@ class EventDrainer implements Runnable {
                         streamEventList.stream()
                                 .map(e -> process(stream, e))
                                 .filter(Objects::nonNull)
-                                .forEach(e -> eventTransmitter.send(e, config.mantisJobCluster(stream)));
+                                .forEach(e -> eventTransmitter.send(e, stream));
                         streamEventList.clear();
                     }
                 } catch (Exception e) {

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/EventDrainer.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/EventDrainer.java
@@ -37,17 +37,19 @@ import org.slf4j.MDC;
 
 class EventDrainer implements Runnable {
 
+    private static final Logger LOG = LoggerFactory.getLogger(EventDrainer.class);
+
     public static final String LOGGING_CONTEXT_KEY = "mantisLogCtx";
     static final String DEFAULT_THREAD_NAME = "mantisDrainer";
     public static final String LOGGING_CONTEXT_VALUE = DEFAULT_THREAD_NAME;
-    private static final Logger LOG = LoggerFactory.getLogger(EventDrainer.class);
+
     private final MrePublishConfiguration config;
     private final Timer mantisEventDrainTimer;
     private final StreamManager streamManager;
+    private final EventProcessor eventProcessor;
     private final EventTransmitter eventTransmitter;
     private final Clock clock;
 
-    private EventProcessor eventProcessor;
 
     EventDrainer(MrePublishConfiguration config,
                  StreamManager streamManager,

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/EventProcessor.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/EventProcessor.java
@@ -66,7 +66,7 @@ class EventProcessor {
      * 2. Check in-memory cache of {@link Subscription}s to find subscriptions whose query match the event.
      * 3. Build a *superset* of fields from *all* matching subscriptions into a single event.o
      *
-     * @return a {@link MantisEvent} which is an internal representation (specific to MRE) of the {@link Event}.
+     * @return a Mantis {@link Event}.
      */
     public Event process(String stream, Event event) {
         LOG.debug("Entering EventProcessor#onNext: {}", event);

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/EventTransmitter.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/EventTransmitter.java
@@ -20,7 +20,9 @@ import io.mantisrx.publish.api.Event;
 
 public interface EventTransmitter {
     /**
-     * Synchronous API to send an event to Mantis.
+     * Send an event to a stream.
+     *
+     * Implementations are free to determine how the events are routed to the stream.
      */
-    void send(Event event, String jobCluster);
+    void send(Event event, String stream);
 }

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/config/MrePublishConfiguration.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/config/MrePublishConfiguration.java
@@ -18,6 +18,8 @@ package io.mantisrx.publish.config;
 
 import java.util.Map;
 
+import io.mantisrx.publish.internal.discovery.MantisJobDiscovery;
+
 
 public interface MrePublishConfiguration {
 
@@ -58,6 +60,10 @@ public interface MrePublishConfiguration {
      */
     Map<String, String> streamNameToJobClusterMapping();
 
+    /**
+     * @deprecated Use {@link MantisJobDiscovery#getJobCluster(String, String)} instead.
+     */
+    @Deprecated
     String mantisJobCluster(String streamName);
 
     int drainerIntervalMsec();

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/config/MrePublishConfiguration.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/config/MrePublishConfiguration.java
@@ -57,7 +57,10 @@ public interface MrePublishConfiguration {
      * List of Mantis Job clusters per stream configured to receive data for this app
      *
      * @return streamName to Job cluster mapping
+     *
+     * @deprecated Use {@link MantisJobDiscovery#getStreamNameToJobClusterMapping(String)} instead.
      */
+    @Deprecated
     Map<String, String> streamNameToJobClusterMapping();
 
     /**

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/MantisJobDiscovery.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/MantisJobDiscovery.java
@@ -17,15 +17,15 @@
 package io.mantisrx.publish.internal.discovery;
 
 
+import java.util.Optional;
+
 import com.netflix.mantis.discovery.proto.AppJobClustersMap;
 import com.netflix.mantis.discovery.proto.JobDiscoveryInfo;
-
-import java.util.Optional;
 
 public interface MantisJobDiscovery {
 
     /**
-     * Lookup streamName to Mantis Job Cluster mappings for an app
+     * Look up streamName to Mantis Job Cluster mappings for an app.
      *
      * @param app name of application
      *
@@ -34,11 +34,21 @@ public interface MantisJobDiscovery {
     Optional<AppJobClustersMap> getJobClusterMappings(String app);
 
     /**
-     * Lookup the current set of Mantis Workers for given Mantis Job Cluster
+     * Look up the current set of Mantis Workers for given Mantis Job Cluster.
      *
      * @param jobCluster name of job cluster
      *
      * @return JobDiscoveryInfo worker locations for the most recent JobID of the job cluster
      */
     Optional<JobDiscoveryInfo> getCurrentJobWorkers(String jobCluster);
+
+    /**
+     * Look up the job cluster for a given app and stream.
+     *
+     * @param app upstream application which is producing events
+     * @param streamName the stream which the upstream application is producing to
+     *
+     * @return Job Cluster string
+     */
+    String getJobCluster(String app, String streamName);
 }

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/MantisJobDiscovery.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/MantisJobDiscovery.java
@@ -17,6 +17,7 @@
 package io.mantisrx.publish.internal.discovery;
 
 
+import java.util.Map;
 import java.util.Optional;
 
 import com.netflix.mantis.discovery.proto.AppJobClustersMap;
@@ -43,12 +44,19 @@ public interface MantisJobDiscovery {
     Optional<JobDiscoveryInfo> getCurrentJobWorkers(String jobCluster);
 
     /**
+     * List of Job Clusters per stream configured to receive data for an app.
+     *
+     * @return Stream name to Job cluster mapping
+     */
+    Map<String, String> getStreamNameToJobClusterMapping(String app);
+
+    /**
      * Look up the job cluster for a given app and stream.
      *
      * @param app upstream application which is producing events
-     * @param streamName the stream which the upstream application is producing to
+     * @param stream the stream which the upstream application is producing to
      *
      * @return Job Cluster string
      */
-    String getJobCluster(String app, String streamName);
+    String getJobCluster(String app, String stream);
 }

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/MantisJobDiscoveryCachingImpl.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/MantisJobDiscoveryCachingImpl.java
@@ -18,6 +18,8 @@ package io.mantisrx.publish.internal.discovery;
 
 import static com.netflix.mantis.discovery.proto.AppJobClustersMap.DEFAULT_APP_KEY;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -122,7 +124,7 @@ public class MantisJobDiscoveryCachingImpl implements MantisJobDiscovery {
     }
 
     @Override
-    public String getJobCluster(String app, String streamName) {
+    public Map<String, String> getStreamNameToJobClusterMapping(String app) {
         String appName = configuration.appName();
         Optional<AppJobClustersMap> jobClusterMappingsO = getJobClusterMappings(appName);
 
@@ -130,9 +132,25 @@ public class MantisJobDiscoveryCachingImpl implements MantisJobDiscovery {
             AppJobClustersMap appJobClustersMap = jobClusterMappingsO.get();
             StreamJobClusterMap streamJobClusterMap = appJobClustersMap.getStreamJobClusterMap(appName);
 
-            return streamJobClusterMap.getJobCluster(streamName);
+            return streamJobClusterMap.getStreamJobClusterMap();
         } else {
-            logger.info("Failed to lookup job cluster for app {} stream {}", appName, streamName);
+            logger.info("Failed to lookup stream to job cluster mapping for app {}", appName);
+            return Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public String getJobCluster(String app, String stream) {
+        String appName = configuration.appName();
+        Optional<AppJobClustersMap> jobClusterMappingsO = getJobClusterMappings(appName);
+
+        if (jobClusterMappingsO.isPresent()) {
+            AppJobClustersMap appJobClustersMap = jobClusterMappingsO.get();
+            StreamJobClusterMap streamJobClusterMap = appJobClustersMap.getStreamJobClusterMap(appName);
+
+            return streamJobClusterMap.getJobCluster(stream);
+        } else {
+            logger.info("Failed to lookup job cluster for app {} stream {}", appName, stream);
             return JOB_CLUSTER_LOOKUP_FAILED;
         }
     }

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/MantisJobDiscoveryStaticImpl.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/MantisJobDiscoveryStaticImpl.java
@@ -17,6 +17,7 @@
 package io.mantisrx.publish.internal.discovery;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +89,7 @@ public class MantisJobDiscoveryStaticImpl implements MantisJobDiscovery {
     }
 
     @Override
-    public String getJobCluster(String app, String streamName) {
+    public Map<String, String> getStreamNameToJobClusterMapping(String app) {
         String appName = DEFAULT_JOB_CLUSTER;
         Optional<AppJobClustersMap> jobClusterMappingsO = getJobClusterMappings(appName);
 
@@ -96,9 +97,25 @@ public class MantisJobDiscoveryStaticImpl implements MantisJobDiscovery {
             AppJobClustersMap appJobClustersMap = jobClusterMappingsO.get();
             StreamJobClusterMap streamJobClusterMap = appJobClustersMap.getStreamJobClusterMap(appName);
 
-            return streamJobClusterMap.getJobCluster(streamName);
+            return streamJobClusterMap.getStreamJobClusterMap();
         } else {
-            logger.info("Failed to lookup job cluster for app {} stream {}", appName, streamName);
+            logger.info("Failed to lookup stream to job cluster mapping for app {}", appName);
+            return Collections.emptyMap();
+        }
+    }
+
+    @Override
+    public String getJobCluster(String app, String stream) {
+        String appName = DEFAULT_JOB_CLUSTER;
+        Optional<AppJobClustersMap> jobClusterMappingsO = getJobClusterMappings(appName);
+
+        if (jobClusterMappingsO.isPresent()) {
+            AppJobClustersMap appJobClustersMap = jobClusterMappingsO.get();
+            StreamJobClusterMap streamJobClusterMap = appJobClustersMap.getStreamJobClusterMap(appName);
+
+            return streamJobClusterMap.getJobCluster(stream);
+        } else {
+            logger.info("Failed to lookup job cluster for app {} stream {}", appName, stream);
             return JOB_CLUSTER_LOOKUP_FAILED;
         }
     }

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/MantisJobDiscoveryStaticImpl.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/MantisJobDiscoveryStaticImpl.java
@@ -30,18 +30,27 @@ import com.netflix.mantis.discovery.proto.AppJobClustersMap;
 import com.netflix.mantis.discovery.proto.JobDiscoveryInfo;
 import com.netflix.mantis.discovery.proto.MantisWorker;
 import com.netflix.mantis.discovery.proto.StageWorkers;
+import com.netflix.mantis.discovery.proto.StreamJobClusterMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Use for local testing. Returns a static JobDiscoveryInfo configuration.
  */
 public class MantisJobDiscoveryStaticImpl implements MantisJobDiscovery {
+
+    private static final Logger logger = LoggerFactory.getLogger(MantisJobDiscoveryCachingImpl.class);
+
     private static final ObjectMapper mapper = new ObjectMapper().registerModule(new Jdk8Module()).configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private static final String DEFAULT_JOB_CLUSTER = "SharedPushEventSource";
+    private static final String JOB_CLUSTER_LOOKUP_FAILED = "JobClusterLookupFailed";
+
     String mreAppJobClusterMapStr="{\"version\": \"1\", "
             + "\"timestamp\": 12345, "
             + "\"mappings\": "
             + "{\"__default__\": {\"requestEventStream\": \"SharedPushRequestEventSource\","
-                                + "\"__default__\": \"SharedPushEventSource\"}}}";
+                                + "\"__default__\": \"" + DEFAULT_JOB_CLUSTER + "\"}}}";
     private AppJobClustersMap appJobClustersMap;
     private String workerHost;
     private int workerPort;
@@ -76,5 +85,21 @@ public class MantisJobDiscoveryStaticImpl implements MantisJobDiscovery {
         stageWorkersMap.put(1, new StageWorkers(jobCluster, jobCluster + "-1",1, workerList));
         JobDiscoveryInfo jobDiscoveryInfo = new JobDiscoveryInfo(jobCluster, jobCluster + "-1",stageWorkersMap);
         return Optional.of(jobDiscoveryInfo);
+    }
+
+    @Override
+    public String getJobCluster(String app, String streamName) {
+        String appName = DEFAULT_JOB_CLUSTER;
+        Optional<AppJobClustersMap> jobClusterMappingsO = getJobClusterMappings(appName);
+
+        if (jobClusterMappingsO.isPresent()) {
+            AppJobClustersMap appJobClustersMap = jobClusterMappingsO.get();
+            StreamJobClusterMap streamJobClusterMap = appJobClustersMap.getStreamJobClusterMap(appName);
+
+            return streamJobClusterMap.getJobCluster(streamName);
+        } else {
+            logger.info("Failed to lookup job cluster for app {} stream {}", appName, streamName);
+            return JOB_CLUSTER_LOOKUP_FAILED;
+        }
     }
 }

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/providers/EventPublisherProvider.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/providers/EventPublisherProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.publish.providers;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import io.mantisrx.publish.MantisEventPublisher;
+import io.mantisrx.publish.StreamManager;
+import io.mantisrx.publish.api.EventPublisher;
+import io.mantisrx.publish.config.MrePublishConfiguration;
+
+/**
+ * Provides an instance of a Mantis {@link EventPublisher}.
+ *
+ * This class can be created standalone via its constructor or created with any injector implementation.
+ */
+@Singleton
+public class EventPublisherProvider implements Provider<EventPublisher> {
+
+    private final MrePublishConfiguration config;
+
+    private final StreamManager streamManager;
+
+    @Inject
+    public EventPublisherProvider(MrePublishConfiguration config, StreamManager streamManager) {
+        this.config = config;
+        this.streamManager = streamManager;
+    }
+
+    @Override
+    @Singleton
+    public EventPublisher get() {
+        return new MantisEventPublisher(config, streamManager);
+    }
+}

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/providers/MantisJobDiscoveryProvider.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/providers/MantisJobDiscoveryProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.publish.providers;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.ipc.http.HttpClient;
+import io.mantisrx.publish.config.MrePublishConfiguration;
+import io.mantisrx.publish.internal.discovery.MantisJobDiscovery;
+import io.mantisrx.publish.internal.discovery.MantisJobDiscoveryCachingImpl;
+import io.mantisrx.publish.internal.discovery.mantisapi.DefaultMantisApiClient;
+
+/**
+ * Provides an instance of a Mantis {@link MantisJobDiscovery}.
+ *
+ * This class can be created standalone via its constructor or created with any injector implementation.
+ */
+@Singleton
+public class MantisJobDiscoveryProvider implements Provider<MantisJobDiscovery> {
+
+    private final MrePublishConfiguration configuration;
+
+    private final Registry registry;
+
+    @Inject
+    public MantisJobDiscoveryProvider(MrePublishConfiguration configuration, Registry registry) {
+        this.configuration = configuration;
+        this.registry = registry;
+    }
+
+    @Override
+    @Singleton
+    public MantisJobDiscovery get() {
+        return new MantisJobDiscoveryCachingImpl(configuration, registry,
+                new DefaultMantisApiClient(configuration, HttpClient.create(registry)));
+    }
+}

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/providers/MrePublishClientInitializerProvider.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/providers/MrePublishClientInitializerProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.publish.providers;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import com.netflix.spectator.api.Registry;
+import io.mantisrx.publish.EventTransmitter;
+import io.mantisrx.publish.MrePublishClientInitializer;
+import io.mantisrx.publish.StreamManager;
+import io.mantisrx.publish.SubscriptionTracker;
+import io.mantisrx.publish.Tee;
+import io.mantisrx.publish.api.EventPublisher;
+import io.mantisrx.publish.config.MrePublishConfiguration;
+
+/**
+ * Provides an instance of a Mantis {@link MrePublishClientInitializer}.
+ *
+ * This class can be created standalone via its constructor or created with any injector implementation.
+ */
+@Singleton
+public class MrePublishClientInitializerProvider implements Provider<MrePublishClientInitializer> {
+
+    private final MrePublishConfiguration config;
+
+    private final Registry registry;
+
+    private final StreamManager streamManager;
+
+    private final EventPublisher eventPublisher;
+
+    private final SubscriptionTracker subscriptionTracker;
+
+    private final EventTransmitter eventTransmitter;
+
+    private final Tee tee;
+
+    @Inject
+    public MrePublishClientInitializerProvider(
+            MrePublishConfiguration config,
+            Registry registry,
+            StreamManager streamManager,
+            EventPublisher eventPublisher,
+            SubscriptionTracker subscriptionTracker,
+            EventTransmitter eventTransmitter,
+            Tee tee) {
+        this.config = config;
+        this.registry = registry;
+        this.streamManager = streamManager;
+        this.eventPublisher = eventPublisher;
+        this.subscriptionTracker = subscriptionTracker;
+        this.eventTransmitter = eventTransmitter;
+        this.tee = tee;
+    }
+
+    @Override
+    @Singleton
+    public MrePublishClientInitializer get() {
+        MrePublishClientInitializer clientInitializer =
+                new MrePublishClientInitializer(
+                        config,
+                        registry,
+                        streamManager,
+                        eventPublisher,
+                        subscriptionTracker,
+                        eventTransmitter,
+                        tee);
+
+        clientInitializer.start();
+
+        return clientInitializer;
+    }
+}

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/providers/StreamManagerProvider.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/providers/StreamManagerProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.publish.providers;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import com.netflix.spectator.api.Registry;
+import io.mantisrx.publish.StreamManager;
+import io.mantisrx.publish.config.MrePublishConfiguration;
+
+/**
+ * Provides an instance of a Mantis {@link StreamManager}.
+ *
+ * This class can be created standalone via its constructor or created with any injector implementation.
+ */
+@Singleton
+public class StreamManagerProvider implements Provider<StreamManager> {
+
+    private final MrePublishConfiguration configuration;
+
+    private final Registry registry;
+
+    @Inject
+    public StreamManagerProvider(MrePublishConfiguration configuration, Registry registry) {
+        this.configuration = configuration;
+        this.registry = registry;
+    }
+
+    @Override
+    @Singleton
+    public StreamManager get() {
+        return new StreamManager(registry, configuration);
+    }
+}

--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/providers/TeeProvider.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/providers/TeeProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.publish.providers;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import com.netflix.spectator.api.Registry;
+import io.mantisrx.publish.NoOpTee;
+import io.mantisrx.publish.Tee;
+
+/**
+ * Provides an instance of a Mantis {@link Tee}.
+ *
+ * This class can be created standalone via its constructor or created with any injector implementation.
+ */
+@Singleton
+public class TeeProvider implements Provider<Tee> {
+
+    private final Registry registry;
+
+    @Inject
+    public TeeProvider(Registry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    @Singleton
+    public Tee get() {
+
+        return new NoOpTee(registry);
+    }
+}

--- a/mantis-publish-core/src/test/java/io/mantisrx/publish/DefaultSubscriptionTrackerTest.java
+++ b/mantis-publish-core/src/test/java/io/mantisrx/publish/DefaultSubscriptionTrackerTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -110,7 +111,9 @@ public class DefaultSubscriptionTrackerTest {
         mantisWorker2.start();
         mantisWorker3.start();
         httpClient = HttpClient.create(registry);
-        subscriptionTracker = new DefaultSubscriptionTracker(mrePublishConfiguration, registry, mockStreamManager, httpClient, mockJobDiscovery);
+        subscriptionTracker = new DefaultSubscriptionTracker(mrePublishConfiguration, registry, mockJobDiscovery, mockStreamManager, httpClient);
+
+        when(mockJobDiscovery.getStreamNameToJobClusterMapping(anyString())).thenReturn(streamJobClusterMap);
     }
 
     @AfterEach

--- a/mantis-publish-netty-guice/src/main/java/io/mantisrx/publish/netty/guice/MantisRealtimeEventsPublishModule.java
+++ b/mantis-publish-netty-guice/src/main/java/io/mantisrx/publish/netty/guice/MantisRealtimeEventsPublishModule.java
@@ -104,9 +104,9 @@ public class MantisRealtimeEventsPublishModule extends AbstractModule {
             return new DefaultSubscriptionTracker(
                     configuration,
                     registry,
+                    jobDiscovery,
                     streamManager,
-                    HttpClient.create(registry),
-                    jobDiscovery);
+                    HttpClient.create(registry));
         }
     }
 

--- a/mantis-publish-netty/src/main/java/io/mantisrx/publish/netty/transmitters/ChoiceOfTwoEventTransmitter.java
+++ b/mantis-publish-netty/src/main/java/io/mantisrx/publish/netty/transmitters/ChoiceOfTwoEventTransmitter.java
@@ -46,6 +46,7 @@ public class ChoiceOfTwoEventTransmitter implements EventTransmitter {
 
     private static final Logger LOG = LoggerFactory.getLogger(ChoiceOfTwoEventTransmitter.class);
 
+    private final MrePublishConfiguration configuration;
     private final Registry registry;
     private final Timer channelSendTime;
     private final MantisJobDiscovery jobDiscovery;
@@ -61,8 +62,8 @@ public class ChoiceOfTwoEventTransmitter implements EventTransmitter {
                                        Registry registry,
                                        MantisJobDiscovery jobDiscovery,
                                        EventChannel eventChannel) {
+        this.configuration = config;
         this.registry = registry;
-
         this.channelSendTime =
                 SpectatorUtils.buildAndRegisterTimer(
                         registry, "sendTime", "channel", HttpEventChannel.CHANNEL_TYPE);
@@ -83,7 +84,9 @@ public class ChoiceOfTwoEventTransmitter implements EventTransmitter {
     }
 
     @Override
-    public void send(Event event, String jobCluster) {
+    public void send(Event event, String stream) {
+        String app = configuration.appName();
+        String jobCluster = jobDiscovery.getJobCluster(app, stream);
         Optional<JobDiscoveryInfo> jobDiscoveryInfo = jobDiscovery.getCurrentJobWorkers(jobCluster);
         if (jobDiscoveryInfo.isPresent()) {
             List<MantisWorker> workers = jobDiscoveryInfo.get().getIngestStageWorkers().getWorkers();

--- a/mantis-publish-netty/src/test/java/io/mantisrx/publish/netty/LocalMrePublishClientInitializer.java
+++ b/mantis-publish-netty/src/test/java/io/mantisrx/publish/netty/LocalMrePublishClientInitializer.java
@@ -112,7 +112,7 @@ public class LocalMrePublishClientInitializer {
         StreamManager streamManager = new StreamManager(registry, mrePublishConfiguration);
         MantisEventPublisher mantisEventPublisher = new MantisEventPublisher(mrePublishConfiguration, streamManager);
         SubscriptionTracker subscriptionsTracker =
-                new DefaultSubscriptionTracker(mrePublishConfiguration, registry, streamManager, httpClient, jobDiscovery);
+                new DefaultSubscriptionTracker(mrePublishConfiguration, registry, jobDiscovery, streamManager, httpClient);
         HttpEventChannelManager channelManager = new HttpEventChannelManager(registry, mrePublishConfiguration);
         EventChannel eventChannel = new HttpEventChannel(registry, channelManager);
         EventTransmitter transmitter =


### PR DESCRIPTION
### Context

Adds providers for users to use with their own DI framework.

Refactor Configuration and Job Discovery logic to move `streamNameToJobClusterMap` and `mantisJobCluster` from Configuration into Job Discovery. This fixes a circular dependency issue and also simplifies the Configuration object to just do configuration. Users of the Job Discovery class, such as SubscriptionTracker and EventEmitter can inject Job Discovery freely.

`EventTransmitter#send` now takes the `String` representing a **stream**, not a `jobCluster`. The transmitter is responsible for routing the event to its destination. This means it will have a job discovery object to figure out which job cluster to send to based on the `app` and `stream`. The `stream` is passed in, and the `app` is retrieved using the `Configuration#appName` which was previously injected into the transmitter on start.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
