### PR TITLE
pin jackson to 2.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext {
     junitVersion = '5.3.+'
     mockitoVersion = '2.18.+'
     slf4jVersion = '1.7.+'
-    jacksonVersion = 'latest.release'
+    jacksonVersion = '2.10.+'
     spectatorVersion = 'latest.release'
     archaiusVersion = 'latest.release'
 }


### PR DESCRIPTION
### Context

pin jackson to 2.10 so it doesn't automatically pull in 2.11 which may cause issues to user apps.

### Checklist

- [ x] `./gradlew build` compiles code correctly
- [x ] Added new tests where applicable
- [x ] `./gradlew test` passes all tests
- [x ] Extended README or added javadocs where applicable
- [x ] Added copyright headers for new files from `CONTRIBUTING.md`
