### PR TITLE
"job cluster mapping fetch url" log -> debug

### DIFF
--- a/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/mantisapi/DefaultMantisApiClient.java
+++ b/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/discovery/mantisapi/DefaultMantisApiClient.java
@@ -88,7 +88,7 @@ public class DefaultMantisApiClient implements MantisApiClient {
             StringBuilder uriBuilder = new StringBuilder(String.format(JOB_CLUSTER_MAPPING_URL_FORMAT, mrePublishConfiguration.discoveryApiHostname(), mrePublishConfiguration.discoveryApiPort()));
             app.ifPresent(appName -> uriBuilder.append("?app=").append(appName));
             String uri = uriBuilder.toString();
-            logger.info("job cluster mapping fetch url {}", uri);
+            logger.debug("job cluster mapping fetch url {}", uri);
             try {
                 HttpResponse response = httpClient.get(URI.create(uri))
                         .withConnectTimeout(CONNECT_TIMEOUT_MS)


### PR DESCRIPTION
Change from info to debug. 

### Context

This recurs on a loop and clutters logs. Most users don't need this information.

### Checklist

- [✅ ] `./gradlew build` compiles code correctly
- [✅ ] Added new tests where applicable
- [✅ ] `./gradlew test` passes all tests
- [✅ ] Extended README or added javadocs where applicable
- [✅ ] Added copyright headers for new files from `CONTRIBUTING.md`
